### PR TITLE
added ubuntu-22 compatibility

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -23,6 +23,7 @@ _php_fpm_directory:
   Ubuntu-17: /etc/php/7.1/fpm
   Ubuntu-18: /etc/php/7.2/fpm
   Ubuntu-19: /etc/php/7.2/fpm
+  Ubuntu-22: /etc/php/8.1/fpm
   Ubuntu: /etc/php/7.4/fpm
 
 php_fpm_directory: "{{ _php_fpm_directory[ansible_distribution ~ '-' ~ ansible_distribution_major_version] | default(_php_fpm_directory[ansible_distribution] | default(_php_fpm_directory['default'] )) }}"
@@ -62,6 +63,7 @@ _php_fpm_service:
   Ubuntu-17: php7.1-fpm.service
   Ubuntu-18: php7.2-fpm.service
   Ubuntu-19: php7.2-fpm.service
+  Ubuntu-22: php8.1-fpm.service
   Ubuntu: php7.4-fpm.service
 
 php_fpm_service: "{{ _php_fpm_service[ansible_distribution ~ '-' ~ ansible_distribution_major_version] | default(_php_fpm_service[ansible_distribution] | default(_php_fpm_service['default'] )) }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -17,6 +17,7 @@ _php_fpm_directory:
   Debian: /etc/php/7.3/fpm
   Debian-testing: &testing_directory /etc/php/7.4/fpm
   Debian-11: *testing_directory
+  Debian-12: /etc/php/8.1/fpm
   Debian-unstable: /etc/php/7.4/fpm
   Fedora: /etc
   openSUSE Leap: /etc/php7/fpm
@@ -58,6 +59,7 @@ _php_fpm_service:
   Debian: php7.3-fpm.service
   Debian-testing: &testing_service php7.4-fpm.service
   Debian-11: *testing_service
+  Debian-12: php8.1-fpm.service
   Debian-unstable: php7.4-fpm.service
   Fedora: php-fpm
   openSUSE Leap: php-fpm

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -23,8 +23,9 @@ _php_fpm_directory:
   Ubuntu-17: /etc/php/7.1/fpm
   Ubuntu-18: /etc/php/7.2/fpm
   Ubuntu-19: /etc/php/7.2/fpm
-  Ubuntu-22: /etc/php/8.1/fpm
-  Ubuntu: /etc/php/7.4/fpm
+  Ubuntu-20: /etc/php/7.4/fpm
+  Ubuntu: /etc/php/8.1/fpm
+
 
 php_fpm_directory: "{{ _php_fpm_directory[ansible_distribution ~ '-' ~ ansible_distribution_major_version] | default(_php_fpm_directory[ansible_distribution] | default(_php_fpm_directory['default'] )) }}"
 
@@ -63,8 +64,8 @@ _php_fpm_service:
   Ubuntu-17: php7.1-fpm.service
   Ubuntu-18: php7.2-fpm.service
   Ubuntu-19: php7.2-fpm.service
-  Ubuntu-22: php8.1-fpm.service
-  Ubuntu: php7.4-fpm.service
+  Ubuntu-20: php7.4-fpm.service
+  Ubuntu: php8.1-fpm.service
 
 php_fpm_service: "{{ _php_fpm_service[ansible_distribution ~ '-' ~ ansible_distribution_major_version] | default(_php_fpm_service[ansible_distribution] | default(_php_fpm_service['default'] )) }}"
 


### PR DESCRIPTION
---
name: Pull request
about: Describe the proposed change

---

**Describe the change**
Ubuntu 22 ships with PHP 8.1 by default, this adds the necessary directory and service

**Testing**
In case a feature was added, how were tests performed?

Local testing on Ubuntu 22.04 solves #1 